### PR TITLE
Improve blog post page design: left-align hero, tighten spacing, clea…

### DIFF
--- a/src/pages/blogs/[...slug].astro
+++ b/src/pages/blogs/[...slug].astro
@@ -154,20 +154,6 @@ const breadcrumbs = [
             </div>
           )}
 
-          <!-- Share buttons -->
-          <div class="blog-post__share">
-            <span class="blog-post__share-label">Share:</span>
-            <a href={twitterShareUrl} target="_blank" rel="noopener noreferrer" class="blog-post__share-btn" aria-label="Share on Twitter">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-              </svg>
-            </a>
-            <a href={linkedInShareUrl} target="_blank" rel="noopener noreferrer" class="blog-post__share-btn" aria-label="Share on LinkedIn">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-              </svg>
-            </a>
-          </div>
         </div>
       </div>
     </header>
@@ -269,24 +255,19 @@ const breadcrumbs = [
 
   /* Hero Header */
   .blog-post__hero {
-    padding: var(--space-12) 0 var(--space-8);
-    position: relative;
-    text-align: center; /* Center align all text */
+    padding: var(--space-8) 0 var(--space-6);
+    text-align: left;
   }
 
-  .blog-post__hero::before {
+  .blog-post__hero::after {
     content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 100%;
-    background: radial-gradient(
-      ellipse 60% 100% at 50% 0%,
-      hsla(28, 100%, 70%, 0.06),
-      transparent
-    );
-    pointer-events: none;
+    display: block;
+    width: 100%;
+    max-width: var(--content-width);
+    margin: 0 auto;
+    height: 2px;
+    background: linear-gradient(90deg, var(--color-accent), var(--gray-200), transparent);
+    border-radius: var(--radius-full);
   }
 
   .blog-post__header {
@@ -297,12 +278,14 @@ const breadcrumbs = [
   .blog-post__meta {
     display: flex;
     align-items: center;
-    justify-content: center; /* Center flex items */
+    justify-content: flex-start;
     gap: var(--space-2);
     font-size: var(--text-sm);
     color: var(--gray-500);
-    font-family: var(--font-mono);
-    margin-bottom: var(--space-4);
+    font-family: var(--font-body);
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    margin-bottom: var(--space-3);
   }
 
   .blog-post__separator {
@@ -316,76 +299,39 @@ const breadcrumbs = [
   .blog-post__title {
     font-size: var(--text-4xl);
     line-height: 1.15;
-    margin-bottom: var(--space-4);
+    margin-bottom: var(--space-3);
     background: linear-gradient(to bottom right, var(--gray-900), var(--gray-700));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 20ch; /* Prevent lines from being too long */
   }
 
   .blog-post__description {
     font-size: var(--text-xl);
     color: var(--gray-600);
     line-height: 1.5;
-    margin-bottom: var(--space-6);
+    margin-bottom: var(--space-4);
     max-width: 60ch;
-    margin-left: auto;
-    margin-right: auto;
   }
 
   .blog-post__tags {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center; /* Center tags */
+    justify-content: flex-start;
     gap: var(--space-2);
-    margin-bottom: var(--space-6);
+    margin-bottom: 0;
   }
 
   .blog-post__tag {
     display: inline-flex;
     padding: var(--space-1) var(--space-3);
     font-size: var(--text-xs);
-    font-weight: 600;
+    font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    background: linear-gradient(135deg, var(--color-accent-glow), hsla(340, 80%, 55%, 0.1));
-    color: var(--color-accent);
-    border-radius: var(--radius-full);
-  }
-
-  .blog-post__share {
-    display: flex;
-    align-items: center;
-    justify-content: center; /* Center share buttons */
-    gap: var(--space-3);
-  }
-
-  .blog-post__share-label {
-    font-size: var(--text-sm);
-    color: var(--gray-500);
-  }
-
-  .blog-post__share-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    background: var(--glass-bg);
-    border: 1px solid var(--gray-200);
-    border-radius: var(--radius-md);
+    background-color: var(--gray-100);
     color: var(--gray-600);
-    transition: all var(--transition-fast);
-  }
-
-  .blog-post__share-btn:hover {
-    background: var(--gray-900);
-    border-color: var(--gray-900);
-    color: white;
-    transform: translateY(-2px);
+    border-radius: var(--radius-full);
   }
 
   /* Content Body */
@@ -605,7 +551,7 @@ const breadcrumbs = [
 
   @media (max-width: 768px) {
     .blog-post__hero {
-      padding: var(--space-8) 0 var(--space-6);
+      padding: var(--space-6) 0 var(--space-4);
     }
 
     .blog-post__title {


### PR DESCRIPTION
Cleaned up visuals

- Left-align all hero text (title, description, meta, tags) for better readability
- Reduce hero vertical padding and inner margins to show content sooner
- Remove share buttons from hero (keep footer share CTA only)
- Switch meta line from monospace to body font for cleaner editorial feel
- Tone down tag styling from gradient to subtle gray pills
- Remove barely-visible hero gradient overlay
- Add subtle accent separator line between hero and content

https://claude.ai/code/session_01YDxrsnUu21QbJie8M8ocaC