### PR TITLE
Enhance /work scanability with stronger hierarchy and extracted impact metrics

### DIFF
--- a/src/data/works.ts
+++ b/src/data/works.ts
@@ -16,8 +16,8 @@ export const works: WorkEntry[] = [
     description:
       'Leading the Conversational Commerce & AI charter. Building a bold 0→1 bet at the intersection of shopping and AI, rethinking how users discover and shop.',
     achievements: [
-      'Spearheading the vision for agentic commerce and AI-first shopping experiences.',
-      'Developing novel interaction paradigms for LLM-powered commerce.',
+      'Driving a 0→1 multi-marketplace AI shopping app with agentic workflows and MCP-based tool interfaces.',
+      'Leading Flipkart’s AI-commerce charter across app, off-app, and partner surfaces with a defensible domain-data moat.',
       'Orchestrating a massive cross-functional effort to redefine the future of Flipkart.',
     ],
     tags: ['AI', 'Strategy', '0→1'],
@@ -36,9 +36,9 @@ export const works: WorkEntry[] = [
     description:
       "Led the end-to-end development of Flippi, Flipkart's AI-powered conversational assistant, scaling it to millions of users.",
     achievements: [
-      'Drove 3M+ MAUs and 1% assisted conversions through intelligent discovery.',
-      'Built an advanced RAG platform and in-house fine-tuned LLMs saving ₹100 Cr+ annually.',
-      'Established the central LLM platform for all GenAI use-cases across the organization.',
+      'Scaled Flippi to 3M+ MAUs with 5% assisted conversions across discovery, research, and post-order journeys.',
+      'Built an advanced RAG platform and in-house fine-tuned LLM systems, unlocking ₹600 Cr+ incremental GMV.',
+      'Improved long-tail and subjective-query relevance by 40% via LLM interpretation and ranking layers.',
     ],
     tags: ['Generative AI', 'LLMs', 'Scale'],
     accentColor: 'hsl(250, 90%, 60%)',
@@ -56,9 +56,9 @@ export const works: WorkEntry[] = [
     description:
       'Drove non-incentivized GMV and Monthly Active Customer growth through rapid, hypothesis-led experimentation across the shopping funnel.',
     achievements: [
-      'Led 70+ A/B experiments across the funnel, resulting in a 1.7% total GMV uplift.',
+      'Executed 50+ high-velocity experiments and 70+ A/B tests across the funnel, resulting in a 1.7% GMV uplift.',
       'Awarded the "Business Excellence" award (top product team in org) for outsized impact.',
-      'Optimized ad conversion rates and launched new formats contributing ₹100 Cr+ bottom-line.',
+      'Drove ₹3,000 Cr GMV uplift through payment and COD funnel optimization; ads improvements added ₹40 Cr to bottom-line.',
     ],
     tags: ['Growth', 'A/B Testing', 'Retention'],
     accentColor: 'hsl(340, 80%, 55%)',
@@ -91,7 +91,8 @@ export const works: WorkEntry[] = [
     description:
       "Built a viral tool during the COVID crisis that scaled to become India's largest private vaccine booking platform.",
     achievements: [
-      'Enabled over 3 Million vaccine slot bookings during the peak of the pandemic.',
+      'Launched the product in 2 weeks and scaled to 10M+ users during the peak of the pandemic.',
+      'Enabled over 3M vaccine slot bookings and acquired 300k new users.',
       'Featured globally as a high-impact solution solving critical distribution friction.',
       'Integrated seamlessly as an in-house tool within the Paytm ecosystem.',
     ],
@@ -112,8 +113,9 @@ export const works: WorkEntry[] = [
       "Architected and launched the Mini App ecosystem to help achieve Paytm's Super-App ambition.",
     achievements: [
       'Grew the platform from ideation to 10M+ MAUs with 600+ merchant partners.',
-      'Built the developer SDK, documentation, and DIY onboarding flows from scratch.',
+      'Built the developer SDK, documentation, and DIY onboarding flows, reducing integration time by 70%.',
       "Launched strategic partnerships with major apps like Ola, Domino's, and Zomato.",
+      'Onboarded 10k developers via a pan-India developer conference and ecosystem push.',
     ],
     tags: ['Super-App', 'Ecosystem', 'SDK'],
     accentColor: 'hsl(200, 100%, 45%)',

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -19,6 +19,18 @@ function highlightMetrics(text: string): string {
     '<strong class="metric">$1</strong>'
   );
 }
+
+function extractTopMetrics(achievements: string[]): string[] {
+  const metricPattern = /(?:₹\s?[\d,.]+\s?(?:Cr|Lakh)?\+?|\d[\d,.]*\+?\s?(?:M|K|Cr|MAU|MAUs|users|bookings|developers|merchant apps|A\/B experiments|%)?)/gi;
+  return [
+    ...new Set(
+      achievements
+        .flatMap((item) => item.match(metricPattern) ?? [])
+        .map((value) => value.trim())
+        .filter((value) => /[0-9]/.test(value))
+    ),
+  ].slice(0, 2);
+}
 ---
 
 <BaseLayout
@@ -140,10 +152,10 @@ function highlightMetrics(text: string): string {
                     />
                   )}
                   <div>
+                    <p class="work-card__role">{work.role}</p>
                     <h2 class="work-card__company">
                       {work.company}
                     </h2>
-                    <p class="work-card__role">{work.role}</p>
                   </div>
                 </div>
 
@@ -153,6 +165,14 @@ function highlightMetrics(text: string): string {
                     <span class="work-card__tag">{tag}</span>
                   ))}
                 </div>
+
+                {extractTopMetrics(work.achievements).length > 0 && (
+                  <div class="work-card__impact-strip">
+                    {extractTopMetrics(work.achievements).map((metric) => (
+                      <span class="work-card__impact-chip">{metric}</span>
+                    ))}
+                  </div>
+                )}
 
                 {/* Divider */}
                 <hr class="work-card__divider" />
@@ -184,6 +204,25 @@ function highlightMetrics(text: string): string {
 </BaseLayout>
 
 <style>
+  .page-header__stats {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--gray-700);
+    font-size: var(--text-base);
+    margin-top: var(--space-3);
+    padding: 0.45rem 0.9rem;
+    border-radius: var(--radius-full);
+    background: var(--gray-100);
+    border: 1px solid var(--gray-200);
+  }
+
+  .page-header__stat strong {
+    font-size: var(--text-lg);
+    font-weight: 800;
+    color: var(--gray-900);
+  }
+
   /* =====================================================
      Work Section & Card List
      ===================================================== */
@@ -260,11 +299,10 @@ function highlightMetrics(text: string): string {
       hsla(28, 100%, 50%, 0.06)
     );
     border-bottom: 1px solid hsla(45, 100%, 50%, 0.15);
-    font-size: var(--text-xs);
-    font-weight: 700;
+    font-size: var(--text-sm);
+    font-weight: 800;
     color: var(--gray-700);
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
+    letter-spacing: 0.01em;
   }
 
   /* Inner padding container */
@@ -301,7 +339,7 @@ function highlightMetrics(text: string): string {
     align-items: center;
     gap: 4px;
     font-size: var(--text-xs);
-    font-weight: 600;
+    font-weight: 500;
     color: var(--gray-400);
     text-decoration: none;
     padding: 3px var(--space-3);
@@ -315,7 +353,7 @@ function highlightMetrics(text: string): string {
   }
 
   .work-card__ext-link:hover {
-    color: var(--accent);
+    color: var(--gray-700);
     background: color-mix(in srgb, var(--accent) 6%, transparent);
     border-color: color-mix(in srgb, var(--accent) 15%, transparent);
   }
@@ -350,19 +388,19 @@ function highlightMetrics(text: string): string {
 
   .work-card__company {
     font-family: var(--font-display);
-    font-size: var(--text-2xl);
-    font-weight: 700;
-    color: var(--gray-900);
+    font-size: var(--text-base);
+    font-weight: 500;
+    color: var(--gray-600);
     line-height: 1.25;
-    margin-bottom: 2px;
+    margin-bottom: 0;
   }
 
   .work-card__role {
-    font-size: var(--text-sm);
-    font-weight: 600;
-    color: var(--accent);
+    font-size: var(--text-xl);
+    font-weight: 700;
+    color: var(--gray-900);
     line-height: 1.4;
-    margin: 0;
+    margin: 0 0 var(--space-1);
   }
 
   /* Tags */
@@ -381,17 +419,36 @@ function highlightMetrics(text: string): string {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: var(--gray-500);
-    background: var(--gray-50);
-    border: 1px solid var(--gray-100);
+    color: color-mix(in srgb, var(--accent) 38%, var(--gray-700));
+    background: color-mix(in srgb, var(--accent) 14%, white);
+    border: 1px solid color-mix(in srgb, var(--accent) 25%, var(--gray-200));
     border-radius: var(--radius-full);
     transition: all var(--transition-fast);
   }
 
   .work-card:hover .work-card__tag {
-    background: white;
-    border-color: var(--gray-200);
-    color: var(--gray-700);
+    background: color-mix(in srgb, var(--accent) 8%, white);
+    border-color: color-mix(in srgb, var(--accent) 30%, var(--gray-200));
+    color: color-mix(in srgb, var(--accent) 45%, var(--gray-700));
+  }
+
+  .work-card__impact-strip {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-4);
+  }
+
+  .work-card__impact-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: var(--radius-full);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    color: color-mix(in srgb, var(--accent) 55%, var(--gray-800));
+    background: color-mix(in srgb, var(--accent) 16%, white);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--gray-200));
   }
 
   /* Divider */
@@ -454,10 +511,6 @@ function highlightMetrics(text: string): string {
       padding: var(--space-5) var(--space-5) var(--space-6);
     }
 
-    .work-card__company {
-      font-size: var(--text-xl);
-    }
-
     .work-card__heading {
       gap: var(--space-3);
     }
@@ -475,6 +528,14 @@ function highlightMetrics(text: string): string {
     .work-card__ext-link {
       font-size: 0.7rem;
       padding: 2px var(--space-2);
+    }
+
+    .work-card__role {
+      font-size: var(--text-lg);
+    }
+
+    .work-card__company {
+      font-size: var(--text-sm);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Improve 10-second recruiter-style scanning by making role the primary visual element and surfacing key metrics earlier.
- Make the hero stats row and award callouts more prominent so credibility and recognition read as signals rather than metadata.
- Reduce visual competition between the date badge and external links while keeping links available in the top row.
- Make tags more meaningful via light accent tinting so categories are scannable at a glance.

### Description
- Swap header order in each work card so the role appears above the company and adjust typography to promote the role and demote the company in CSS (`src/pages/work.astro`).
- Add `extractTopMetrics(achievements)` to auto-extract the top 1–2 numeric metrics from achievement strings and render an impact strip of chips above the divider in each card (`src/pages/work.astro`).
- De-emphasize external links visually by lowering contrast and hover emphasis, and strengthen hero stats presentation with a pill-style container and bolder numeric tokens (`src/pages/work.astro` CSS edits).
- Improve award banner weight and apply light accent tinting to tags so they convey category meaning; add styling for the new impact chips; update several achievement lines in `src/data/works.ts` using the provided resume data to improve metric quality for extraction.

### Testing
- Ran `npm run build` and the static site build completed successfully with `/work` generated as part of the build.
- Verified the build log shows successful page generation and optimized assets with no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a133d895e8483258b0019845e935bbe)