### PR TITLE
[codex] Unify UI vibes blog, builder, and reference

### DIFF
--- a/public/ui-vibes-reference.html
+++ b/public/ui-vibes-reference.html
@@ -830,7 +830,7 @@
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
         <span class="copy-fab__label">Copy <span id="copy-fab__vibe">Editorial</span> prompt</span>
     </button>
-    <a class="copy-fab__link" href="/vibes/" aria-label="Customize this vibe into a prompt">
+    <a class="copy-fab__link" href="/vibes/?vibe=editorial#builder" data-builder-link aria-label="Customize this vibe into a prompt">
         Customize →
     </a>
 </div>
@@ -865,14 +865,14 @@
                 <p class="lg:hidden text-slate-300 text-[15px] leading-relaxed mt-4">Eight complete screens to help you pick a direction before you prompt.</p>
                 <p class="hidden lg:block text-slate-300 text-lg leading-relaxed max-w-2xl mt-5">These are the eight UI directions I keep reusing. Compare the full screens, pick the closest one, and save yourself a few rounds of fixing generic UI later.</p>
                 <div class="grid grid-cols-2 gap-2.5 mt-6 lg:hidden">
-                    <a href="/vibes/" class="inline-flex items-center justify-center rounded-lg bg-white text-slate-950 px-3 py-2.5 text-sm font-semibold hover:bg-slate-200 transition-colors">Build my prompt</a>
+                    <a href="/vibes/?vibe=editorial#builder" data-builder-link class="inline-flex items-center justify-center rounded-lg bg-white text-slate-950 px-3 py-2.5 text-sm font-semibold hover:bg-slate-200 transition-colors">Use Editorial</a>
                     <a href="/blogs/picking-the-right-ui-for-vibe-coding/" class="inline-flex items-center justify-center rounded-lg border border-slate-700 text-white px-3 py-2.5 text-sm font-medium hover:border-slate-500 hover:bg-slate-900 transition-colors">Read the framework</a>
                 </div>
             </div>
             <div class="hidden lg:block lg:border-l lg:border-slate-800 lg:pl-8">
                 <p class="text-sm leading-relaxed text-slate-300 mb-5">Pick the one that feels closest to what you are building. You can copy its prompt as-is or tune it in the prompt builder.</p>
                 <div class="flex flex-wrap gap-3">
-                    <a href="/vibes/" class="inline-flex items-center justify-center rounded-lg bg-white text-slate-950 px-4 py-2.5 text-sm font-semibold hover:bg-slate-200 transition-colors">Build my prompt</a>
+                    <a href="/vibes/?vibe=editorial#builder" data-builder-link class="inline-flex items-center justify-center rounded-lg bg-white text-slate-950 px-4 py-2.5 text-sm font-semibold hover:bg-slate-200 transition-colors">Use Editorial in my prompt</a>
                     <a href="/blogs/picking-the-right-ui-for-vibe-coding/" class="inline-flex items-center justify-center rounded-lg border border-slate-700 text-white px-4 py-2.5 text-sm font-medium hover:border-slate-500 hover:bg-slate-900 transition-colors">Read the framework</a>
                 </div>
             </div>
@@ -888,7 +888,10 @@
                 <span class="hidden sm:inline font-mono text-[10px] uppercase tracking-[0.16em] text-slate-400">Selected</span>
                 <p class="text-xs sm:text-sm text-slate-700"><strong id="active-vibe-name" class="text-slate-950">Editorial</strong><span class="text-slate-300 mx-1.5">/</span><span id="active-vibe-summary">Calm, text-first, and typographic.</span></p>
             </div>
-            <p id="active-vibe-fit" class="hidden md:block text-xs text-slate-500">Best for long-form reading, portfolios, and thoughtful tools.</p>
+            <div class="flex items-center gap-4">
+                <p id="active-vibe-fit" class="hidden lg:block text-xs text-slate-500">Best for long-form reading, portfolios, and thoughtful tools.</p>
+                <a href="/vibes/?vibe=editorial#builder" data-builder-link class="inline-flex items-center justify-center rounded-md bg-slate-950 text-white px-3 py-2 text-xs font-semibold whitespace-nowrap hover:bg-slate-800 transition-colors">Use Editorial →</a>
+            </div>
         </div>
         <div class="nav-scroll-wrapper">
             <div class="nav-scroll-track" role="tablist" aria-label="UI vibe examples">
@@ -896,8 +899,8 @@
                 <button type="button" id="tab-utility" role="tab" aria-selected="false" aria-controls="utility" tabindex="-1" onclick="switchTab('utility')" class="nav-btn tab-trigger flex flex-col items-start justify-center px-4 md:px-5 py-2.5 text-gray-500 hover:text-black font-medium border-b-2 border-transparent whitespace-nowrap focus:outline-none transition-colors text-xs md:text-sm" data-tab="utility"><span class="nav-btn__index">02</span><span>Utility</span></button>
                 <button type="button" id="tab-warm" role="tab" aria-selected="false" aria-controls="warm" tabindex="-1" onclick="switchTab('warm')" class="nav-btn tab-trigger flex flex-col items-start justify-center px-4 md:px-5 py-2.5 text-gray-500 hover:text-black font-medium border-b-2 border-transparent whitespace-nowrap focus:outline-none transition-colors text-xs md:text-sm" data-tab="warm"><span class="nav-btn__index">03</span><span>Warm Consumer</span></button>
                 <button type="button" id="tab-sharp" role="tab" aria-selected="false" aria-controls="sharp" tabindex="-1" onclick="switchTab('sharp')" class="nav-btn tab-trigger flex flex-col items-start justify-center px-4 md:px-5 py-2.5 text-gray-500 hover:text-black font-medium border-b-2 border-transparent whitespace-nowrap focus:outline-none transition-colors text-xs md:text-sm" data-tab="sharp"><span class="nav-btn__index">04</span><span>Sharp Product</span></button>
-                <button type="button" id="tab-playful" role="tab" aria-selected="false" aria-controls="playful" tabindex="-1" onclick="switchTab('playful')" class="nav-btn tab-trigger flex flex-col items-start justify-center px-4 md:px-5 py-2.5 text-gray-500 hover:text-black font-medium border-b-2 border-transparent whitespace-nowrap focus:outline-none transition-colors text-xs md:text-sm" data-tab="playful"><span class="nav-btn__index">05</span><span>Playful</span></button>
-                <button type="button" id="tab-softsaas" role="tab" aria-selected="false" aria-controls="softsaas" tabindex="-1" onclick="switchTab('softsaas')" class="nav-btn nav-btn-softsaas tab-trigger flex flex-col items-start justify-center px-4 md:px-5 py-2.5 text-gray-500 hover:text-indigo-600 font-medium border-b-2 border-transparent whitespace-nowrap focus:outline-none transition-colors text-xs md:text-sm" data-tab="softsaas"><span class="nav-btn__index">06</span><span>Soft SaaS</span></button>
+                <button type="button" id="tab-softsaas" role="tab" aria-selected="false" aria-controls="softsaas" tabindex="-1" onclick="switchTab('softsaas')" class="nav-btn nav-btn-softsaas tab-trigger flex flex-col items-start justify-center px-4 md:px-5 py-2.5 text-gray-500 hover:text-indigo-600 font-medium border-b-2 border-transparent whitespace-nowrap focus:outline-none transition-colors text-xs md:text-sm" data-tab="softsaas"><span class="nav-btn__index">05</span><span>Soft SaaS</span></button>
+                <button type="button" id="tab-playful" role="tab" aria-selected="false" aria-controls="playful" tabindex="-1" onclick="switchTab('playful')" class="nav-btn tab-trigger flex flex-col items-start justify-center px-4 md:px-5 py-2.5 text-gray-500 hover:text-black font-medium border-b-2 border-transparent whitespace-nowrap focus:outline-none transition-colors text-xs md:text-sm" data-tab="playful"><span class="nav-btn__index">06</span><span>Playful</span></button>
                 <button type="button" id="tab-brutalist" role="tab" aria-selected="false" aria-controls="brutalist" tabindex="-1" onclick="switchTab('brutalist')" class="nav-btn nav-btn-brutalist tab-trigger flex flex-col items-start justify-center px-4 md:px-5 py-2.5 text-gray-500 hover:text-black font-medium border-b-2 border-transparent whitespace-nowrap focus:outline-none transition-colors text-xs md:text-sm" data-tab="brutalist"><span class="nav-btn__index">07</span><span>Brutalist</span></button>
                 <button type="button" id="tab-glass" role="tab" aria-selected="false" aria-controls="glass" tabindex="-1" onclick="switchTab('glass')" class="nav-btn nav-btn-glass tab-trigger flex flex-col items-start justify-center px-4 md:px-5 py-2.5 text-gray-500 hover:text-[#5E5CE6] font-medium border-b-2 border-transparent whitespace-nowrap focus:outline-none transition-colors text-xs md:text-sm" data-tab="glass"><span class="nav-btn__index">08</span><span>Glass / Spatial</span></button>
             </div>
@@ -3448,9 +3451,19 @@
             document.getElementById('active-vibe-name').textContent = meta.name;
             document.getElementById('active-vibe-summary').textContent = meta.summary;
             document.getElementById('active-vibe-fit').textContent = meta.fit;
+            document.querySelectorAll('[data-builder-link]').forEach(link => {
+                link.href = `/vibes/?vibe=${meta.key}#builder`;
+                if (link.classList.contains('copy-fab__link')) return;
+                link.textContent = link.closest('#vibe-chooser')
+                    ? `Use ${meta.name} →`
+                    : `Use ${meta.name} in my prompt`;
+            });
             const fabBtn = document.getElementById('copy-fab__btn');
             fabBtn?.classList.remove('is-copied');
             expandFab();
+        }
+        if (window.location.hash !== `#${tabId}`) {
+            window.history.replaceState({}, '', `#${tabId}`);
         }
     }
 
@@ -3637,11 +3650,9 @@
         }
     }
 
-    // Set initial active state
-    document.querySelector('[data-tab="editorial"]').classList.remove('text-gray-500', 'border-transparent');
-    document.querySelector('[data-tab="editorial"]').classList.add('text-black', 'border-black');
-    document.querySelector('[data-tab="editorial"]').classList.add('is-active');
-    document.querySelectorAll('.tab-content:not(#editorial)').forEach(panel => { panel.hidden = true; });
+    // Restore a directly linked vibe, falling back to Editorial.
+    const initialVibeId = window.location.hash.slice(1);
+    switchTab(VIBE_MAP[initialVibeId] ? initialVibeId : 'editorial');
 
     // Demo links with no destination should not jump the reference back to the top.
     document.addEventListener('click', (event) => {

--- a/src/content/blog/picking-the-right-ui-for-vibe-coding.md
+++ b/src/content/blog/picking-the-right-ui-for-vibe-coding.md
@@ -20,8 +20,13 @@ I [vibe-code almost every day](https://princejain.me/blogs/vibe-coding-what-i-bu
 _A note: I'm a PM, not a designer. What follows isn't a design system manifesto. It's the cheat sheet I keep going back to so that what I ship doesn't look like everyone else's first prompt._
 
 <aside class="skip-ahead">
-  <p class="skip-ahead__eyebrow">SKIP AHEAD</p>
-  <p class="skip-ahead__body">Want to just use it? <a href="/vibes/">Open the UI Vibes reference</a> — copy the prompts, or jump from there into the full HTML visual reference.</p>
+  <p class="skip-ahead__eyebrow">SKIP THE THEORY</p>
+  <h2 class="skip-ahead__title">Build your UI prompt in under two minutes.</h2>
+  <p class="skip-ahead__body">Choose how the product should feel, choose the screen you are building, and get a copy-ready prompt.</p>
+  <div class="skip-ahead__actions">
+    <a class="skip-ahead__primary" href="/vibes/#builder">Build my UI prompt →</a>
+    <a class="skip-ahead__secondary" href="/ui-vibes-reference.html">Compare all 8 visually</a>
+  </div>
 </aside>
 
 ---
@@ -108,12 +113,15 @@ Same component, eight skins. Tap a name to swap. Each redraws the card with the 
   </div>
 
   <div class="vibe-switcher__actions">
+    <a class="vibe-builder-link" data-vibe-builder-link href="/vibes/?vibe=editorial#builder">
+      Use <span data-active-vibe-name>Editorial</span> in the prompt builder →
+    </a>
     <button class="vibe-copy" type="button" data-action="copy-active-vibe">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-      <span class="vibe-copy__label">Copy this vibe's prompt</span>
+      <span class="vibe-copy__label">Copy vibe only</span>
     </button>
     <p class="vibe-switcher__caption">
-      Want all 8 side-by-side? <a href="/vibes/">Browse the full library →</a>
+      Want to see the complete screen? <a data-vibe-reference-link href="/ui-vibes-reference.html#editorial">Open the Editorial reference →</a>
     </p>
   </div>
 </div>
@@ -172,7 +180,7 @@ Non-negotiables:
 
 The second prompt is longer, but it usually saves prompts overall. It gives the model fewer visual decisions to improvise, and gives me a much better first version to react to.
 
-I do not write this block from scratch every time. I have pre-built the design-system directions for all eight vibes on the [UI Vibes reference page](/vibes/). I copy one, add the product context, and adjust only what is specific to the build.
+I do not write this block from scratch every time. I keep all eight directions in the [UI prompt builder](/vibes/#builder). I choose the vibe and screen, add the product context if it matters, and copy the generated prompt.
 
 ---
 
@@ -203,6 +211,16 @@ One minute of "Warm Consumer + single-screen tool" is cheaper than thirty minute
 
 And the choice itself is not purely a design skill. Knowing which direction fits a product is a judgment call about the user, the task, and what the experience should communicate. That is a product decision. The prompt is just where it gets expressed.
 
+<aside class="article-cta">
+  <p class="article-cta__eyebrow">PUT IT TO WORK</p>
+  <h2>Pick the direction. Get the prompt. Start building.</h2>
+  <p>The builder combines one of these eight UI directions with the screen you are making and gives you a prompt ready for Claude, Cursor, v0, or Lovable.</p>
+  <div class="article-cta__actions">
+    <a class="article-cta__primary" href="/vibes/#builder">Build my UI prompt →</a>
+    <a class="article-cta__secondary" href="/ui-vibes-reference.html">Compare the 8 full interfaces</a>
+  </div>
+</aside>
+
 ---
 
 _This is the first post in a short series on getting more out of Claude Code and vibe-coding tools. Next up: writing prompts the model actually follows — XML structure, anti-patterns, and why specificity beats verbosity. After that: choosing a stack, iterating without burning context, and shipping a vibe-coded prototype past the demo._
@@ -214,33 +232,76 @@ _If you're vibe-coding and want to compare notes on any of this, find me on [Twi
      Skip-ahead callout (top of post)
      ============================================================ */
   .skip-ahead {
-    margin: 1.75rem 0 0;
-    padding: 16px 20px;
-    background: linear-gradient(180deg, #FFF7EE 0%, #FFFAF3 100%);
-    border: 1px solid #F0E0C5;
-    border-left: 3px solid var(--color-accent, #FF6B00);
-    border-radius: 8px;
+    margin: 2rem 0 0;
+    padding: 24px;
+    background: var(--gray-900);
+    border: 1px solid var(--gray-800);
+    border-radius: 12px;
+    box-shadow: var(--shadow-lg);
   }
   .skip-ahead__eyebrow {
     font-size: 10px;
     letter-spacing: 0.14em;
     font-weight: 700;
     color: var(--color-accent, #FF6B00);
-    margin: 0 0 4px;
+    margin: 0 0 8px;
+  }
+  .skip-ahead__title {
+    margin: 0 0 8px;
+    color: white;
+    font-size: 24px;
+    line-height: 1.2;
   }
   .skip-ahead__body {
     margin: 0;
+    max-width: 620px;
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--gray-300);
+  }
+  .skip-ahead__actions,
+  .article-cta__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 18px;
+  }
+  .skip-ahead__actions a,
+  .article-cta__actions a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 0 16px;
+    border-radius: 8px;
     font-size: 14px;
-    line-height: 1.55;
-    color: var(--gray-700);
-  }
-  .skip-ahead__body a {
-    color: var(--gray-900);
     font-weight: 600;
-    text-decoration: underline;
-    text-underline-offset: 3px;
+    text-decoration: none;
   }
-  .skip-ahead__body a:hover { color: var(--color-accent, #FF6B00); }
+  .skip-ahead__primary {
+    background: var(--color-accent, #FF6B00);
+    color: white;
+  }
+  .skip-ahead__primary:hover {
+    background: var(--color-accent-light, #FF8533);
+    color: white;
+  }
+  .skip-ahead__secondary {
+    border: 1px solid var(--gray-600);
+    color: var(--gray-100);
+  }
+  .skip-ahead__secondary:hover {
+    border-color: var(--gray-400);
+    color: white;
+  }
+  .blog-post__content .skip-ahead__actions .skip-ahead__primary {
+    color: var(--gray-50);
+    text-decoration: none;
+  }
+  .blog-post__content .skip-ahead__actions .skip-ahead__secondary {
+    color: var(--gray-100);
+    text-decoration: none;
+  }
 
   /* ============================================================
      Vibe switcher — inline interactive widget
@@ -306,17 +367,35 @@ _If you're vibe-coding and want to compare notes on any of this, find me on [Twi
 
   .vibe-switcher__actions {
     display: flex;
-    flex-direction: column;
     align-items: flex-start;
+    flex-wrap: wrap;
     gap: 10px;
     margin-top: 4px;
   }
-  .vibe-copy {
-    appearance: none;
+  .vibe-builder-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 42px;
+    padding: 0 18px;
     border: 1px solid var(--gray-900);
+    border-radius: 8px;
     background: var(--gray-900);
     color: white;
-    padding: 10px 18px;
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .vibe-builder-link:hover {
+    background: black;
+    color: white;
+  }
+  .vibe-copy {
+    appearance: none;
+    min-height: 42px;
+    border: 1px solid var(--gray-300);
+    background: white;
+    color: var(--gray-800);
+    padding: 0 16px;
     border-radius: 8px;
     font-size: 13px;
     font-weight: 600;
@@ -327,13 +406,17 @@ _If you're vibe-coding and want to compare notes on any of this, find me on [Twi
     gap: 8px;
   }
   .vibe-copy svg { opacity: 0.85; }
-  .vibe-copy:hover { background: black; }
+  .vibe-copy:hover {
+    border-color: var(--gray-500);
+    background: var(--gray-50);
+  }
   .vibe-copy:active { transform: scale(0.98); }
   .vibe-copy.is-copied {
     background: var(--color-accent, #FF6B00);
     border-color: var(--color-accent, #FF6B00);
   }
   .vibe-switcher__caption {
+    flex-basis: 100%;
     font-size: 12px;
     color: var(--gray-500);
     margin: 0;
@@ -346,6 +429,49 @@ _If you're vibe-coding and want to compare notes on any of this, find me on [Twi
     font-weight: 500;
   }
   .vibe-switcher__caption a:hover { color: var(--color-accent, #FF6B00); }
+
+  .article-cta {
+    margin: 3rem 0 2rem;
+    padding: 28px;
+    border: 1px solid var(--gray-200);
+    border-radius: 12px;
+    background: var(--gray-50);
+  }
+  .article-cta__eyebrow {
+    margin: 0 0 8px;
+    color: var(--color-accent, #FF6B00);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+  }
+  .article-cta h2 {
+    margin: 0 0 10px;
+    font-size: 28px;
+    line-height: 1.2;
+  }
+  .article-cta > p:not(.article-cta__eyebrow) {
+    margin: 0;
+    color: var(--gray-600);
+    font-size: 15px;
+    line-height: 1.6;
+  }
+  .article-cta__primary {
+    background: var(--gray-900);
+    color: white;
+  }
+  .article-cta__primary:hover {
+    background: black;
+    color: white;
+  }
+  .article-cta__secondary {
+    border: 1px solid var(--gray-300);
+    background: white;
+    color: var(--gray-800);
+  }
+  .article-cta__secondary:hover {
+    border-color: var(--gray-500);
+    color: var(--gray-900);
+  }
 
   /* ============================================================
      Per-vibe token scopes — the only place the look changes
@@ -476,6 +602,13 @@ _If you're vibe-coding and want to compare notes on any of this, find me on [Twi
   @media (max-width: 768px) {
     .vibe-stage { min-height: 220px; padding: 24px 16px; }
     .vibe-sample { max-width: 100%; }
+    .skip-ahead__actions a,
+    .article-cta__actions a,
+    .vibe-builder-link,
+    .vibe-copy {
+      width: 100%;
+      justify-content: center;
+    }
   }
 </style>
 
@@ -487,6 +620,39 @@ _If you're vibe-coding and want to compare notes on any of this, find me on [Twi
     const pills = switcher.querySelectorAll('[data-set-vibe]');
     const copyBtn = switcher.querySelector('[data-action="copy-active-vibe"]');
     const copyLabel = copyBtn?.querySelector('.vibe-copy__label');
+    const builderLink = switcher.querySelector('[data-vibe-builder-link]');
+    const referenceLink = switcher.querySelector('[data-vibe-reference-link]');
+    const activeVibeName = switcher.querySelector('[data-active-vibe-name]');
+    const vibeNames = {
+      editorial: 'Editorial',
+      utility: 'Utility',
+      'warm-consumer': 'Warm Consumer',
+      'sharp-product': 'Sharp Product',
+      'soft-saas': 'Soft SaaS',
+      playful: 'Playful',
+      brutalist: 'Brutalist',
+      'glass-spatial': 'Glass / Spatial',
+    };
+    const referenceIds = {
+      editorial: 'editorial',
+      utility: 'utility',
+      'warm-consumer': 'warm',
+      'sharp-product': 'sharp',
+      'soft-saas': 'softsaas',
+      playful: 'playful',
+      brutalist: 'brutalist',
+      'glass-spatial': 'glass',
+    };
+
+    function updateVibeLinks(vibe) {
+      const name = vibeNames[vibe] ?? 'this vibe';
+      if (builderLink) builderLink.href = `/vibes/?vibe=${vibe}#builder`;
+      if (activeVibeName) activeVibeName.textContent = name;
+      if (referenceLink) {
+        referenceLink.href = `/ui-vibes-reference.html#${referenceIds[vibe] ?? vibe}`;
+        referenceLink.textContent = `Open the ${name} reference →`;
+      }
+    }
 
     pills.forEach((pill) => {
       pill.addEventListener('click', () => {
@@ -498,6 +664,7 @@ _If you're vibe-coding and want to compare notes on any of this, find me on [Twi
           p.classList.toggle('is-active', isActive);
           p.setAttribute('aria-selected', String(isActive));
         });
+        updateVibeLinks(vibe);
         window.gtag?.('event', 'vibe_previewed', { vibe_id: vibe });
       });
     });

--- a/src/pages/vibes.astro
+++ b/src/pages/vibes.astro
@@ -7,16 +7,6 @@ import {
   stackOptions,
   vibes,
 } from '../data/vibes';
-import type { VibeCategory } from '../types';
-
-const categories: Array<'All' | VibeCategory> = [
-  'All',
-  'Content',
-  'Internal tools',
-  'Consumer',
-  'B2B',
-  'Experimental',
-];
 
 const defaultVibe = vibes[0];
 const defaultScreen = screenTypes[0];
@@ -38,29 +28,49 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     <section class="vibes-hero">
       <div class="container">
         <p class="vibes-hero__eyebrow">UI PROMPT BUILDER</p>
-        <h1 class="vibes-hero__title">Pick the UI before you start prompting.</h1>
+        <h1 class="vibes-hero__title">Build a better UI prompt in under two minutes.</h1>
         <p class="vibes-hero__subtitle">
-          Choose how the product should feel and what kind of screen you are building.
-          Get a copy-ready prompt that saves iterations, context, and tokens.
+          Pick how it should feel. Pick the screen you are building. Copy a prompt that gives your
+          coding model less room to fall back to generic UI.
         </p>
+        <ol class="vibes-hero__steps" aria-label="How the prompt builder works">
+          <li><span>1</span>Choose a vibe</li>
+          <li><span>2</span>Choose a screen</li>
+          <li><span>3</span>Copy the prompt</li>
+        </ol>
+        <div class="vibes-hero__actions">
+          <a class="vibes-hero__primary" href="#builder">Start with the UI direction →</a>
+          <a class="vibes-hero__secondary" href="/ui-vibes-reference.html">Not sure? Compare all 8</a>
+        </div>
         <div class="vibes-hero__meta">
-          <a href="/blogs/picking-the-right-ui-for-vibe-coding/">Read how I use this framework</a>
+          <a href="/blogs/picking-the-right-ui-for-vibe-coding/">Why this saves tokens and rework</a>
           <span aria-hidden="true">·</span>
           <span>No signup. Nothing leaves your browser.</span>
         </div>
       </div>
     </section>
 
-    <section class="vibe-builder" aria-labelledby="builder-title">
+    <section class="vibe-builder" id="builder" aria-labelledby="builder-title">
       <div class="container">
         <div class="builder-heading">
           <p class="builder-heading__eyebrow">BUILD YOUR PROMPT</p>
-          <h2 id="builder-title">Two choices first. Project context second.</h2>
+          <h2 id="builder-title">Choose, choose, copy.</h2>
           <p>
-            Start with the direction and screen shape. The generated prompt updates as you make
-            each choice.
+            The prompt updates as you go. Project details are optional and can be added before you
+            copy.
           </p>
         </div>
+
+        <aside class="compare-panel">
+          <div>
+            <p class="compare-panel__eyebrow">NEED TO SEE THE DIFFERENCE?</p>
+            <h3>Compare all eight as complete interfaces.</h3>
+            <p>Use the visual reference if the thumbnails are not enough to make the choice.</p>
+          </div>
+          <a href="/ui-vibes-reference.html" data-reference-link>
+            Open the full visual reference →
+          </a>
+        </aside>
 
         <section class="builder-step" aria-labelledby="vibe-step-title">
           <div class="builder-step__heading">
@@ -71,19 +81,6 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
             <p>Choose the closest direction. You can tune the details after the first build.</p>
           </div>
 
-          <div class="vibe-filters" role="group" aria-label="Filter UI directions">
-            {categories.map((category) => (
-              <button
-                class:list={['vibe-filter', { 'is-active': category === 'All' }]}
-                type="button"
-                data-vibe-filter={category}
-                aria-pressed={category === 'All' ? 'true' : 'false'}
-              >
-                {category}
-              </button>
-            ))}
-          </div>
-
           <div class="vibe-grid" data-vibe-grid>
             {vibes.map((vibe, index) => (
               <button
@@ -91,7 +88,6 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
                 type="button"
                 data-vibe-option={vibe.id}
                 data-vibe={vibe.id}
-                data-categories={vibe.categories.join('|')}
                 aria-pressed={index === 0 ? 'true' : 'false'}
               >
                 <span class="vibe-option__preview" aria-hidden="true">
@@ -228,6 +224,18 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
               </button>
             ))}
           </div>
+
+          <div class="builder-next">
+            <p>Selected: <strong data-selected-vibe-next>{defaultVibe.name}</strong></p>
+            <div>
+              <a href="/ui-vibes-reference.html#editorial" data-selected-reference>
+                See the full example
+              </a>
+              <a class="builder-next__primary" href="#screen-step-title">
+                Next: choose the screen ↓
+              </a>
+            </div>
+          </div>
         </section>
 
         <section class="builder-step" aria-labelledby="screen-step-title">
@@ -360,17 +368,25 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
             </div>
             <p class="screen-carousel__hint">Swipe, scroll, or use the arrows</p>
           </div>
+
+          <div class="builder-next">
+            <p>Selected: <strong data-selected-screen-next>{defaultScreen.name}</strong></p>
+            <div>
+              <a class="builder-next__primary" href="#prompt-step-title">
+                Next: copy the prompt ↓
+              </a>
+            </div>
+          </div>
         </section>
 
-        <section class="builder-step" aria-labelledby="context-step-title">
-          <div class="builder-step__heading">
-            <div>
-              <p class="builder-step__number">03</p>
-              <h3 id="context-step-title">Add the project context.</h3>
-            </div>
-            <p>Optional, but this is what turns a reusable direction into your product.</p>
-          </div>
-
+        <details class="project-context">
+          <summary>
+            <span>
+              <strong>Add project details</strong>
+              <small>Optional, but makes the prompt specific to your product.</small>
+            </span>
+            <span aria-hidden="true">+</span>
+          </summary>
           <div class="project-fields">
             <label class="project-field">
               <span>Project name</span>
@@ -400,12 +416,12 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
               ></textarea>
             </label>
           </div>
-        </section>
+        </details>
 
         <section class="builder-step builder-step--prompt" aria-labelledby="prompt-step-title">
           <div class="builder-step__heading builder-step__heading--prompt">
             <div>
-              <p class="builder-step__number">04</p>
+              <p class="builder-step__number">03</p>
               <h3 id="prompt-step-title">Copy the prompt.</h3>
             </div>
             <label class="prompt-detail">
@@ -430,71 +446,13 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
                 </button>
               </div>
             </div>
-            <pre class="prompt-output__pre" data-no-copy><code data-generated-prompt>{defaultPrompt}</code></pre>
+            <details class="prompt-inspector">
+              <summary>Inspect the full prompt</summary>
+              <pre class="prompt-output__pre" data-no-copy><code data-generated-prompt>{defaultPrompt}</code></pre>
+            </details>
             <p class="prompt-output__status" data-copy-status aria-live="polite"></p>
           </div>
         </section>
-      </div>
-    </section>
-
-    <section class="vibe-reference" aria-labelledby="reference-title">
-      <div class="container">
-        <div class="section-heading">
-          <p class="section-heading__eyebrow">DETAILED REFERENCE</p>
-          <h2 id="reference-title">Need to compare the directions more closely?</h2>
-          <p>
-            The builder above is for choosing quickly. These notes show the references and full
-            design specification behind each direction.
-          </p>
-        </div>
-
-        <div class="reference-list">
-          {vibes.map((vibe) => (
-            <article class="reference-item" id={vibe.id}>
-              <div class="reference-item__summary">
-                <div class="reference-item__identity">
-                  <span
-                    class="reference-item__swatch"
-                    data-vibe-swatch={vibe.id}
-                    aria-hidden="true"
-                  ></span>
-                  <div>
-                    <h3><a href={`#${vibe.id}`}>{vibe.name}</a></h3>
-                    <p>{vibe.blurb}</p>
-                  </div>
-                </div>
-              </div>
-
-              <p class="reference-item__use"><strong>Best for:</strong> {vibe.useFor}</p>
-              <ul class="reference-item__brands" aria-label={`${vibe.name} references`}>
-                {vibe.references.map((reference) => <li>{reference}</li>)}
-              </ul>
-
-              <details class="reference-item__details">
-                <summary>Read the design specification</summary>
-                <pre data-no-copy><code>{vibe.designSystem}</code></pre>
-              </details>
-            </article>
-          ))}
-        </div>
-      </div>
-    </section>
-
-    <section class="playground-panel">
-      <div class="container">
-        <div class="playground-panel__inner">
-          <div>
-            <p class="playground-panel__eyebrow">FULL COMPONENT PLAYGROUND</p>
-            <h2>Inspect every direction across a complete interface.</h2>
-            <p>
-              The standalone reference includes larger page examples, component states, responsive
-              layouts, and interactive details. It is useful once you have narrowed the choice.
-            </p>
-          </div>
-          <a href="/ui-vibes-reference.html" target="_blank" rel="noopener noreferrer">
-            Open the full visual reference ↗
-          </a>
-        </div>
       </div>
     </section>
 
@@ -528,8 +486,7 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
   }
   .vibes-hero__eyebrow,
   .builder-heading__eyebrow,
-  .section-heading__eyebrow,
-  .playground-panel__eyebrow {
+  .compare-panel__eyebrow {
     margin-bottom: var(--space-3);
     color: var(--color-accent);
     font-size: var(--text-xs);
@@ -551,6 +508,67 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     font-size: var(--text-lg);
     line-height: 1.6;
   }
+  .vibes-hero__steps {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3) var(--space-6);
+    margin: var(--space-6) 0 0;
+    padding: 0;
+    color: var(--gray-700);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    list-style: none;
+  }
+  .vibes-hero__steps li {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .vibes-hero__steps span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-full);
+    background: var(--gray-900);
+    color: white;
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+  }
+  .vibes-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    margin-top: var(--space-6);
+  }
+  .vibes-hero__actions a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 46px;
+    padding: 0 var(--space-5);
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    text-decoration: none;
+  }
+  .vibes-hero__primary {
+    background: var(--gray-900);
+    color: white;
+  }
+  .vibes-hero__primary:hover {
+    background: var(--gray-800);
+  }
+  .vibes-hero__secondary {
+    border: 1px solid var(--gray-300);
+    background: white;
+    color: var(--gray-800);
+  }
+  .vibes-hero__secondary:hover {
+    border-color: var(--gray-500);
+    color: var(--gray-900);
+  }
   .vibes-hero__meta {
     display: flex;
     flex-wrap: wrap;
@@ -571,25 +589,60 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
   .vibe-builder {
     padding: var(--space-12) 0 var(--space-24);
   }
-  .builder-heading,
-  .section-heading {
+  .builder-heading {
     max-width: 720px;
     margin-bottom: var(--space-12);
   }
-  .builder-heading h2,
-  .section-heading h2,
-  .playground-panel h2 {
+  .builder-heading h2 {
     margin-bottom: var(--space-3);
     color: var(--gray-900);
     font-family: var(--font-display);
     font-size: var(--text-3xl);
     line-height: 1.15;
   }
-  .builder-heading > p:last-child,
-  .section-heading > p:last-child,
-  .playground-panel p {
+  .builder-heading > p:last-child {
     color: var(--gray-600);
     line-height: 1.65;
+  }
+
+  .compare-panel {
+    display: grid;
+    gap: var(--space-5);
+    margin-bottom: var(--space-4);
+    padding: var(--space-6);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    background: var(--gray-50);
+  }
+  .compare-panel__eyebrow {
+    margin-bottom: var(--space-2);
+  }
+  .compare-panel h3 {
+    margin-bottom: var(--space-2);
+    color: var(--gray-900);
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+  }
+  .compare-panel p:last-child {
+    color: var(--gray-600);
+    font-size: var(--text-sm);
+    line-height: 1.55;
+  }
+  .compare-panel > a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 46px;
+    padding: 0 var(--space-5);
+    border-radius: var(--radius-md);
+    background: var(--gray-900);
+    color: white;
+    font-size: var(--text-sm);
+    font-weight: 700;
+    text-decoration: none;
+  }
+  .compare-panel > a:hover {
+    background: var(--gray-800);
   }
 
   .builder-step {
@@ -623,44 +676,6 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     font-weight: 700;
-  }
-
-  .vibe-filters {
-    display: flex;
-    gap: var(--space-2);
-    margin-bottom: var(--space-6);
-    padding-bottom: var(--space-1);
-    overflow-x: auto;
-    scrollbar-width: none;
-  }
-  .vibe-filters::-webkit-scrollbar {
-    display: none;
-  }
-  .vibe-filter {
-    min-height: 40px;
-    padding: 0 var(--space-4);
-    border: 1px solid var(--gray-300);
-    border-radius: var(--radius-full);
-    background: white;
-    color: var(--gray-600);
-    font: inherit;
-    font-size: var(--text-sm);
-    font-weight: 600;
-    white-space: nowrap;
-    cursor: pointer;
-    transition:
-      color var(--transition-fast),
-      border-color var(--transition-fast),
-      background var(--transition-fast);
-  }
-  .vibe-filter:hover {
-    border-color: var(--gray-500);
-    color: var(--gray-900);
-  }
-  .vibe-filter.is-active {
-    border-color: var(--gray-900);
-    background: var(--gray-900);
-    color: white;
   }
 
   .vibe-grid {
@@ -1492,6 +1507,54 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     font-size: var(--text-xs);
     line-height: 1.45;
   }
+  .builder-next {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    margin-top: var(--space-6);
+    padding: var(--space-4);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-md);
+    background: var(--gray-50);
+  }
+  .builder-next p {
+    margin: 0;
+    color: var(--gray-600);
+    font-size: var(--text-sm);
+  }
+  .builder-next p strong {
+    color: var(--gray-900);
+  }
+  .builder-next > div {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+  }
+  .builder-next a {
+    color: var(--gray-700);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    text-decoration: none;
+  }
+  .builder-next a:hover {
+    color: var(--color-accent);
+  }
+  .builder-next .builder-next__primary {
+    display: inline-flex;
+    align-items: center;
+    min-height: 40px;
+    padding: 0 var(--space-4);
+    border-radius: var(--radius-md);
+    background: var(--gray-900);
+    color: white;
+  }
+  .builder-next .builder-next__primary:hover {
+    background: var(--gray-800);
+    color: white;
+  }
 
   .builder-step__heading--carousel,
   .builder-step__heading--prompt {
@@ -1899,6 +1962,48 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     display: grid;
     gap: var(--space-5);
   }
+  .project-context {
+    margin: 0 0 var(--space-4);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    background: var(--gray-50);
+  }
+  .project-context > summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-5);
+    color: var(--gray-900);
+    cursor: pointer;
+    list-style: none;
+  }
+  .project-context > summary::-webkit-details-marker {
+    display: none;
+  }
+  .project-context > summary > span:first-child {
+    display: grid;
+    gap: var(--space-1);
+  }
+  .project-context > summary strong {
+    font-size: var(--text-base);
+  }
+  .project-context > summary small {
+    color: var(--gray-500);
+    font-size: var(--text-sm);
+    font-weight: 400;
+  }
+  .project-context > summary > span:last-child {
+    color: var(--color-accent);
+    font-size: var(--text-2xl);
+    transition: transform var(--transition-fast);
+  }
+  .project-context[open] > summary > span:last-child {
+    transform: rotate(45deg);
+  }
+  .project-context .project-fields {
+    padding: 0 var(--space-5) var(--space-5);
+  }
   .project-field {
     display: grid;
     gap: var(--space-2);
@@ -2029,6 +2134,17 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     white-space: pre-wrap;
     tab-size: 2;
   }
+  .prompt-inspector {
+    border-top: 1px solid var(--gray-200);
+  }
+  .prompt-inspector > summary {
+    padding: var(--space-3) var(--space-5);
+    background: white;
+    color: var(--gray-700);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    cursor: pointer;
+  }
   .prompt-output__pre code {
     padding: 0;
     border-radius: 0;
@@ -2050,162 +2166,6 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     background: white;
     color: var(--gray-600);
     font-size: var(--text-xs);
-  }
-
-  .vibe-reference {
-    padding: var(--space-24) 0;
-    background: var(--gray-50);
-  }
-  .reference-list {
-    border-top: 1px solid var(--gray-200);
-  }
-  .reference-item {
-    padding: var(--space-8) 0;
-    border-bottom: 1px solid var(--gray-200);
-    scroll-margin-top: var(--space-16);
-  }
-  .reference-item__summary {
-    display: grid;
-    gap: var(--space-5);
-  }
-  .reference-item__identity {
-    display: grid;
-    grid-template-columns: 52px 1fr;
-    gap: var(--space-4);
-  }
-  .reference-item__swatch {
-    width: 52px;
-    height: 52px;
-    border: 1px solid var(--gray-200);
-    border-radius: var(--radius-md);
-    background: var(--gray-100);
-  }
-  .reference-item__swatch[data-vibe-swatch='editorial'] {
-    background: linear-gradient(135deg, #fafaf7 50%, #0b1f3a 50%);
-  }
-  .reference-item__swatch[data-vibe-swatch='utility'] {
-    background: linear-gradient(135deg, #fafafa 50%, #3b82f6 50%);
-  }
-  .reference-item__swatch[data-vibe-swatch='warm-consumer'] {
-    background: linear-gradient(135deg, #fffaf3 50%, #d97757 50%);
-  }
-  .reference-item__swatch[data-vibe-swatch='sharp-product'] {
-    background: linear-gradient(135deg, #ffffff 50%, #4f46e5 50%);
-  }
-  .reference-item__swatch[data-vibe-swatch='soft-saas'] {
-    background: linear-gradient(135deg, #eaf7ff, #8b5cf6);
-  }
-  .reference-item__swatch[data-vibe-swatch='playful'] {
-    background: linear-gradient(135deg, #ffd93d 50%, #ff6b6b 50%);
-  }
-  .reference-item__swatch[data-vibe-swatch='brutalist'] {
-    border: 2px solid #000000;
-    border-radius: 0;
-    background: linear-gradient(135deg, #ffffff 50%, #ffff00 50%);
-  }
-  .reference-item__swatch[data-vibe-swatch='glass-spatial'] {
-    background: linear-gradient(135deg, #edf0f6, #5e5ce6 65%, #ff80b0);
-  }
-  .reference-item h3 {
-    margin-bottom: var(--space-1);
-    font-family: var(--font-display);
-    font-size: var(--text-xl);
-  }
-  .reference-item h3 a {
-    color: var(--gray-900);
-    text-decoration: none;
-  }
-  .reference-item h3 a:hover {
-    color: var(--color-accent);
-  }
-  .reference-item__identity p,
-  .reference-item__use {
-    color: var(--gray-600);
-    font-size: var(--text-sm);
-    line-height: 1.55;
-  }
-  .reference-item__use {
-    margin-top: var(--space-4);
-  }
-  .reference-item__brands {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-    margin: var(--space-3) 0 0;
-    padding: 0;
-    list-style: none;
-  }
-  .reference-item__brands li {
-    padding: 4px 9px;
-    border-radius: var(--radius-full);
-    background: var(--gray-100);
-    color: var(--gray-600);
-    font-size: var(--text-xs);
-  }
-  .reference-item__details {
-    margin-top: var(--space-4);
-  }
-  .reference-item__details summary {
-    color: var(--gray-700);
-    font-size: var(--text-sm);
-    font-weight: 600;
-    cursor: pointer;
-  }
-  .reference-item__details pre {
-    max-height: 420px;
-    margin-top: var(--space-4);
-    padding: var(--space-5);
-    overflow: auto;
-    border: 1px solid var(--gray-200);
-    border-radius: var(--radius-md);
-    background: white;
-    color: var(--gray-800);
-    font-family: var(--font-mono);
-    font-size: 12px;
-    line-height: 1.6;
-    white-space: pre-wrap;
-  }
-  .reference-item__details pre code {
-    padding: 0;
-    border-radius: 0;
-    background: transparent;
-    color: inherit;
-    font: inherit;
-    line-height: inherit;
-    white-space: inherit;
-  }
-
-  .playground-panel {
-    padding: var(--space-16) 0;
-  }
-  .playground-panel__inner {
-    display: grid;
-    gap: var(--space-6);
-    padding: var(--space-8);
-    border: 1px solid var(--gray-200);
-    border-radius: var(--radius-lg);
-    background: white;
-    box-shadow: var(--shadow-md);
-  }
-  .playground-panel h2 {
-    font-size: var(--text-2xl);
-  }
-  .playground-panel a {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 48px;
-    padding: 0 var(--space-5);
-    border-radius: var(--radius-md);
-    background: var(--gray-900);
-    color: white;
-    font-size: var(--text-sm);
-    font-weight: 700;
-    text-decoration: none;
-    white-space: nowrap;
-  }
-  .playground-panel a:hover {
-    background: var(--gray-800);
   }
 
   .vibes-footer {
@@ -2263,7 +2223,7 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     .screen-option {
       flex-basis: 380px;
     }
-    .playground-panel__inner {
+    .compare-panel {
       grid-template-columns: minmax(0, 1fr) auto;
       align-items: center;
     }
@@ -2290,6 +2250,18 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     }
     .prompt-copy {
       width: 100%;
+    }
+    .vibes-hero__actions a,
+    .compare-panel > a {
+      width: 100%;
+    }
+    .builder-next,
+    .builder-next > div {
+      align-items: stretch;
+      flex-direction: column;
+    }
+    .builder-next a {
+      text-align: center;
     }
   }
 </style>
@@ -2320,9 +2292,6 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
   const screenButtons = Array.from(
     document.querySelectorAll<HTMLButtonElement>('[data-screen-option]')
   );
-  const filterButtons = Array.from(
-    document.querySelectorAll<HTMLButtonElement>('[data-vibe-filter]')
-  );
   const screenDots = Array.from(
     document.querySelectorAll<HTMLButtonElement>('[data-screen-dot]')
   );
@@ -2332,7 +2301,14 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
   const carousel = document.querySelector<HTMLElement>('[data-screen-carousel]');
   const generatedPrompt = document.querySelector<HTMLElement>('[data-generated-prompt]');
   const selectedVibe = document.querySelector<HTMLElement>('[data-selected-vibe]');
+  const selectedVibeNext =
+    document.querySelector<HTMLElement>('[data-selected-vibe-next]');
   const selectedScreen = document.querySelector<HTMLElement>('[data-selected-screen]');
+  const selectedScreenNext =
+    document.querySelector<HTMLElement>('[data-selected-screen-next]');
+  const selectedReference =
+    document.querySelector<HTMLAnchorElement>('[data-selected-reference]');
+  const referenceLink = document.querySelector<HTMLAnchorElement>('[data-reference-link]');
   const tokenEstimate = document.querySelector<HTMLElement>('[data-token-estimate]');
   const carouselStatus = document.querySelector<HTMLElement>('[data-carousel-status]');
   const copyStatus = document.querySelector<HTMLElement>('[data-copy-status]');
@@ -2343,6 +2319,16 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
   const stackSelect = document.querySelector<HTMLSelectElement>('[data-stack]');
   const promptModeSelect =
     document.querySelector<HTMLSelectElement>('[data-prompt-mode-select]');
+  const referenceIds: Record<string, string> = {
+    editorial: 'editorial',
+    utility: 'utility',
+    'warm-consumer': 'warm',
+    'sharp-product': 'sharp',
+    'soft-saas': 'softsaas',
+    playful: 'playful',
+    brutalist: 'brutalist',
+    'glass-spatial': 'glass',
+  };
 
   function getActiveVibe() {
     return vibes.find((vibe) => vibe.id === builderState.vibeId) ?? vibes[0];
@@ -2390,9 +2376,17 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     const screen = getActiveScreen();
     if (generatedPrompt) generatedPrompt.textContent = prompt;
     if (selectedVibe) selectedVibe.textContent = vibe.name;
+    if (selectedVibeNext) selectedVibeNext.textContent = vibe.name;
     if (selectedScreen) selectedScreen.textContent = screen.name;
+    if (selectedScreenNext) selectedScreenNext.textContent = screen.name;
     if (tokenEstimate) tokenEstimate.textContent = `≈ ${Math.ceil(prompt.length / 4)} tokens`;
     if (mainCopyLabel) mainCopyLabel.textContent = 'Copy prompt';
+    const referenceUrl = `/ui-vibes-reference.html#${referenceIds[vibe.id] ?? vibe.id}`;
+    if (selectedReference) {
+      selectedReference.href = referenceUrl;
+      selectedReference.textContent = `See the full ${vibe.name} example`;
+    }
+    if (referenceLink) referenceLink.href = referenceUrl;
 
     const screenIndex = screenTypes.findIndex((item) => item.id === screen.id);
     if (carouselStatus) {
@@ -2415,6 +2409,9 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     builderState.vibeId = vibeId;
     setPressedState(vibeButtons, vibeId, 'vibeOption');
     renderPrompt();
+    const url = new URL(window.location.href);
+    url.searchParams.set('vibe', vibeId);
+    window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
   }
 
   function scrollScreenIntoView(screenTypeId: string) {
@@ -2439,28 +2436,6 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
   function selectPromptMode(mode: PromptMode) {
     builderState.mode = mode;
     renderPrompt();
-  }
-
-  function setFilter(filter: string) {
-    filterButtons.forEach((button) => {
-      const isSelected = button.dataset.vibeFilter === filter;
-      button.classList.toggle('is-active', isSelected);
-      button.setAttribute('aria-pressed', String(isSelected));
-    });
-
-    vibeButtons.forEach((button) => {
-      const categories = button.dataset.categories?.split('|') ?? [];
-      button.hidden = filter !== 'All' && !categories.includes(filter);
-    });
-
-    const activeButton = vibeButtons.find(
-      (button) => button.dataset.vibeOption === builderState.vibeId
-    );
-    if (activeButton?.hidden) {
-      const firstVisible = vibeButtons.find((button) => !button.hidden);
-      const nextVibeId = firstVisible?.dataset.vibeOption;
-      if (nextVibeId) selectVibe(nextVibeId);
-    }
   }
 
   function moveCarousel(direction: number) {
@@ -2509,13 +2484,6 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
     button.addEventListener('click', () => {
       const screenTypeId = button.dataset.screenOption;
       if (screenTypeId) selectScreen(screenTypeId, true);
-    });
-  });
-
-  filterButtons.forEach((button) => {
-    button.addEventListener('click', () => {
-      const filter = button.dataset.vibeFilter;
-      if (filter) setFilter(filter);
     });
   });
 
@@ -2586,6 +2554,12 @@ const defaultPrompt = buildCompactPrompt(defaultVibe, {
       );
     }
   );
+
+  const initialVibeId = new URLSearchParams(window.location.search).get('vibe');
+  if (initialVibeId && vibes.some((vibe) => vibe.id === initialVibeId)) {
+    builderState.vibeId = initialVibeId;
+    setPressedState(vibeButtons, initialVibeId, 'vibeOption');
+  }
 
   renderPrompt();
 </script>


### PR DESCRIPTION
## What changed
- made the blog CTA prominent and fixed its text contrast against the blog link styles
- simplified `/vibes` into a clear choose-vibe, choose-screen, copy-prompt flow
- made project context and raw prompt inspection optional
- connected the blog, builder, and full reference with selected-vibe deep links
- added contextual use-this-vibe actions to the full visual reference

## Why
The three surfaces overlapped and did not provide a clear next action. This gives each page one job and preserves the user's selected vibe between them.

## Validation
- `npm run build`
- inline script parse checks
- `git diff --check`
